### PR TITLE
Volume revert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-media-stack-volumes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,8 +73,8 @@ services:
       - 51413:51413/udp
     volumes:
       - tx-config:/config
-      - ./media-stack-volumes/torrent-downloads:/downloads
-      - ./media-stack-volumes/tx-watch:/watch
+      - torrent-downloads:/downloads
+      - tx-watch:/watch
     restart: "unless-stopped"
 
   ## Default credentials - Username: admin password: adminadmin ##
@@ -93,7 +93,7 @@ services:
       - WEBUI_PORT=5080
     volumes:
       - qbittorrent-config:/config
-      - ./media-stack-volumes/torrent-downloads:/downloads
+      - torrent-downloads:/downloads
 
     ## Uncomment below ports if VPN is disabled.
     # ports:
@@ -115,7 +115,7 @@ services:
       - 7878:7878
     volumes:
       - radarr-config:/config
-      - ./media-stack-volumes/torrent-downloads:/downloads
+      - torrent-downloads:/downloads
     restart: "unless-stopped"
 
   sonarr:
@@ -130,7 +130,7 @@ services:
       - TZ=UTC
     volumes:
       - sonarr-config:/config
-      - ./media-stack-volumes/torrent-downloads:/downloads
+      - torrent-downloads:/downloads
     ports:
       - 8989:8989
     restart: unless-stopped
@@ -147,7 +147,7 @@ services:
       - TZ=UTC
     volumes:
       - jackett-config:/config
-      - ./media-stack-volumes/jackett-blackhole:/downloads
+      - jackett-blackhole:/downloads
     ports:
       - 9117:9117
     restart: unless-stopped
@@ -180,7 +180,7 @@ services:
       - TZ=UTC
     volumes:
       - jellyfin-config:/config
-      - ./media-stack-volumes/torrent-downloads:/data
+      - torrent-downloads:/data
   # devices:
    #  - /dev/videoN:/dev/videoN # Mount GPU device 
     ports:
@@ -190,13 +190,16 @@ services:
     restart: unless-stopped
 
 volumes:
+  torrent-downloads:
   radarr-config:
   sonarr-config:
   jackett-config:
+  jackett-blackhole:
   prowlarr-config:
   jellyfin-config:
   qbittorrent-config:
   tx-config:
+  tx-watch:
 
 networks:
   mynetwork:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,8 +73,8 @@ services:
       - 51413:51413/udp
     volumes:
       - tx-config:/config
-      - $HOME/media-stack-volumes/torrent-downloads:/downloads
-      - $HOME/media-stack-volumes/tx-watch:/watch
+      - ./media-stack-volumes/torrent-downloads:/downloads
+      - ./media-stack-volumes/tx-watch:/watch
     restart: "unless-stopped"
 
   ## Default credentials - Username: admin password: adminadmin ##
@@ -93,7 +93,7 @@ services:
       - WEBUI_PORT=5080
     volumes:
       - qbittorrent-config:/config
-      - $HOME/media-stack-volumes/torrent-downloads:/downloads
+      - ./media-stack-volumes/torrent-downloads:/downloads
 
     ## Uncomment below ports if VPN is disabled.
     # ports:
@@ -115,7 +115,7 @@ services:
       - 7878:7878
     volumes:
       - radarr-config:/config
-      - $HOME/media-stack-volumes/torrent-downloads:/downloads
+      - ./media-stack-volumes/torrent-downloads:/downloads
     restart: "unless-stopped"
 
   sonarr:
@@ -130,7 +130,7 @@ services:
       - TZ=UTC
     volumes:
       - sonarr-config:/config
-      - $HOME/media-stack-volumes/torrent-downloads:/downloads
+      - ./media-stack-volumes/torrent-downloads:/downloads
     ports:
       - 8989:8989
     restart: unless-stopped
@@ -147,7 +147,7 @@ services:
       - TZ=UTC
     volumes:
       - jackett-config:/config
-      - $HOME/media-stack-volumes/jackett-blackhole:/downloads
+      - ./media-stack-volumes/jackett-blackhole:/downloads
     ports:
       - 9117:9117
     restart: unless-stopped
@@ -180,7 +180,7 @@ services:
       - TZ=UTC
     volumes:
       - jellyfin-config:/config
-      - $HOME/media-stack-volumes/torrent-downloads:/data
+      - ./media-stack-volumes/torrent-downloads:/data
   # devices:
    #  - /dev/videoN:/dev/videoN # Mount GPU device 
     ports:


### PR DESCRIPTION
Revert volume bind to docker volume. Since there is no performance benefit of bind mount over docker volume. Docker volume is easy to manage. Server does not need easily accessible directory for movies.