### PR TITLE
Added device mount for tun on vpn service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,12 @@ services:
 
     networks:
       - mynetwork
-    
+
+    # # Uncomment below when using VPN in an LXC container
+    # # Make sure to mount /dev/net/tun and /dev/net from underlaying host into your LXC.
+    # devices:
+    #   - /dev/net/tun:/dev/net/tun
+      
     # Uncomment/enable below ports if VPN is used/enabled
     # ports:
     #   # qbittorrent ports


### PR DESCRIPTION
VPN service will fail to start up in an LXC containers' docker instance complaining about permissions / access to the devices' TUN, either there is no TUN, or it can't modify it.

Adding this line allows the tun of the host Proxmox system to be mounted into the docker container once it's been mounted to the LXC.

Discussion that inspired this change: https://github.com/qdm12/gluetun/discussions/1482