### PR TITLE
update Jellyseerr image to current Seerr release

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,18 +172,19 @@ services:
       - 3000:3000
     restart: unless-stopped
 
-  jellyseerr:
+  seerr:
     profiles: ["vpn", "no-vpn"]
-    image: ghcr.io/seerr-team/seerr:3.0.1
-    container_name: jellyseerr
+    image: ghcr.io/seerr-team/seerr:v3.0.1
+    container_name: seerr
     networks:
       - mynetwork
     environment:
       - PUID=1000
       - PGID=1000
       - TZ=UTC
+      - PORT=5055
     volumes:
-      - jellyseerr-config:/app/config
+      - seerr-config:/app/config
     ports:
       - 5055:5055
     restart: unless-stopped
@@ -248,7 +249,7 @@ volumes:
   prowlarr-config:
   jellyfin-config:
   qbittorrent-config:
-  jellyseerr-config:
+  seerr-config:
   recommendarr-data:
   # cleanmyarr-config:
 


### PR DESCRIPTION
## Update Jellyseerr image

The current compose file pins Jellyseerr to:

fallenbagel/jellyseerr:2.7.3

This version is outdated and prevents the stack from running newer Jellyseerr releases.

This PR updates the image reference to:

ghcr.io/seerr-team/seerr:3.0.1

This ensures the stack runs a current upstream release while remaining fully compatible with the existing configuration.

Tested locally with no additional configuration changes required.