### PR TITLE
Update docker image versions to align with selfhosted media-stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
   qbittorrent:
     profiles: ["vpn", "no-vpn"]
     container_name: qbittorrent
-    image: lscr.io/linuxserver/qbittorrent:5.2.2
+    image: lscr.io/linuxserver/qbittorrent:5.2.3
 
     # Unomment below if vpn is enabled
     # depends_on:               # Uncomment this line if vpn is enabled
@@ -95,7 +95,7 @@ services:
   radarr:
     profiles: ["vpn", "no-vpn"]
     container_name: radarr
-    image: lscr.io/linuxserver/radarr:6.2.1
+    image: lscr.io/linuxserver/radarr:6.3.0
     networks:
       - mynetwork   # Comment this line if VPN is enabled
     ## Uncomment below lines if VPN is enabled
@@ -114,7 +114,7 @@ services:
 
   sonarr:
     profiles: ["vpn", "no-vpn"]
-    image: linuxserver/sonarr:4.0.17
+    image: linuxserver/sonarr:4.0.19
     container_name: sonarr
     networks:
       - mynetwork   # Comment this line if VPN is enabled
@@ -135,7 +135,7 @@ services:
   prowlarr:
     profiles: ["vpn", "no-vpn"]
     container_name: prowlarr
-    image: linuxserver/prowlarr:2.4.0
+    image: linuxserver/prowlarr:2.5.2
 
     # Uncomment below if vpn is enabled
     # depends_on:               # Uncomment this line if vpn is enabled
@@ -176,7 +176,7 @@ services:
 
   seerr:
     profiles: ["vpn", "no-vpn"]
-    image: ghcr.io/seerr-team/seerr:v3.3.0
+    image: ghcr.io/seerr-team/seerr:v3.4.0
     container_name: seerr
     networks:
       - mynetwork


### PR DESCRIPTION
## Changes

Updated image versions in `docker-compose.yml` to match the versions running in the selfhosted media-server stack (`media-server/docker-compose-media-stack.yml`).

| Service | Old Version | New Version |
|---|---|---|
| qbittorrent | `5.2.2` | `5.2.3` |
| radarr | `6.2.1` | `6.3.0` |
| sonarr | `4.0.17` | `4.0.19` |
| prowlarr | `2.4.0` | `2.5.2` |
| seerr | `v3.3.0` | `v3.4.0` |

## Unchanged

The following services already had matching versions between both repos:
- **gluetun**: `v3.41.1`
- **jellyfin**: `10.11.11`
- **recommendarr**: `v1.4.4`
- **traefik**: `v3.6.13` (docker-compose-traefik.yml)
- **nginx**: `1.27.1-alpine` (docker-compose-nginx.yml)
- **cleanmyarr**: `0.8.1` (commented out)

## Verification

- ✅ All image versions now match between `navilg/media-stack` and `navilg/selfhosted`'s `media-server/docker-compose-media-stack.yml`
- ✅ No structural changes to compose file — only version tags updated